### PR TITLE
Update sidekiq-limit_fetch.gemspec

### DIFF
--- a/sidekiq-limit_fetch.gemspec
+++ b/sidekiq-limit_fetch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'sidekiq-limit_fetch'
-  gem.version       = '3.4.0'
+  gem.version       = '3.4.1'
   gem.license       = 'MIT'
   gem.authors       = 'brainopia'
   gem.email         = 'brainopia@evilmartians.com'


### PR DESCRIPTION
Bump version so that the bulk_requeue change gets pulled during `bundle update` if brainopia/sidekiq-limit_fetch v. 3.4.0 is already in Gemfile.lock